### PR TITLE
[VELRM-1532] VPS: убраны следы Rescue в velvica-js-client

### DIFF
--- a/src/ControlPanelApi.js
+++ b/src/ControlPanelApi.js
@@ -10,7 +10,6 @@ export const VPSStateChange = Object.freeze({
   SHUTDOWN: 'shutdown',
   SOFT_REBOOT: 'softReboot',
   HARD_REBOOT: 'hardReboot',
-  RESCUE_LEAVE: 'rescueLeave'
 });
 
 /**
@@ -28,7 +27,7 @@ export class ControlPanelApi extends AbstractApi {
    * @param {string} endpoint
    * @param {string} agSign
    * @param {string} subscriptionId
-   * @param [Fetcher] fetcher
+   * @param {Fetcher} [fetcher]
    */
   constructor({endpoint, agSign, subscriptionId}, fetcher = new Fetcher()) {
     super({endpoint, agSign}, fetcher);
@@ -112,19 +111,10 @@ export class ControlPanelApi extends AbstractApi {
       [VPSStateChange.SOFT_REBOOT]: 'reboot/soft',
       [VPSStateChange.HARD_REBOOT]: 'reboot/hard',
       [VPSStateChange.SHUTDOWN]: 'shutdown',
-      [VPSStateChange.TURN_ON]: 'start',
-      [VPSStateChange.RESCUE_LEAVE]: 'rescue/leave'
+      [VPSStateChange.TURN_ON]: 'start'
     };
 
     return this.fetch(mapping[stateChange], {method: 'POST'});
-  }
-
-  async startRescue(imageId) {
-    return this.fetch(`rescue/start?image_id=${imageId}`, {method: 'POST'});
-  }
-
-  async leaveRescue() {
-    return this.fetch('rescue/leave', {method: 'POST'});
   }
 
   async fetchConsoleUrl() {

--- a/src/PartnerApi.js
+++ b/src/PartnerApi.js
@@ -18,7 +18,7 @@ export class PartnerApi extends AbstractApi {
   /**
    * @protected
    * @param {string} action
-   * @param {object} queryParams
+   * @param {object} urlParams
    * @returns {string}
    */
   buildRequestPath(action, urlParams) {
@@ -54,7 +54,7 @@ export class PartnerApi extends AbstractApi {
    */
 
   /**
-   * @param [object] filters
+   * @param {object} [filters]
    * @returns {Promise<Response>}
    */
   async fetchSubscriptions(filters) {

--- a/tests/control-panel-api-tests.js
+++ b/tests/control-panel-api-tests.js
@@ -1,6 +1,6 @@
 import {describe, it, before} from "mocha";
 import {expect} from 'chai';
-import {ControlPanelApi, VPSLogFilter, VPSStateChange} from "../src/ControlPanelApi";
+import {ControlPanelApi, VPSLogFilter, VPSStateChange} from "../src";
 import {createFetcherStub} from "./util";
 
 const ENDPOINT = 'ENDPOINT';

--- a/tests/control-panel-api-tests.js
+++ b/tests/control-panel-api-tests.js
@@ -61,20 +61,6 @@ describe('ControlPanelApi', function () {
         params: {method: 'POST'}
       }
     },
-    'startRescue': {
-      action: () => api.startRescue('abc'),
-      expected: {
-        url: '[E]/subscription/[S]/rescue/start?image_id=abc&[A]',
-        params: {method: 'POST'}
-      }
-    },
-    'leaveRescue': {
-      action: () => api.leaveRescue(),
-      expected: {
-        url: '[E]/subscription/[S]/rescue/leave?[A]',
-        params: {method: 'POST'}
-      }
-    },
     'fetchConsoleUrl': {
       action: () => api.fetchConsoleUrl(),
       expected: {

--- a/tests/partner-api-tests.js
+++ b/tests/partner-api-tests.js
@@ -1,8 +1,7 @@
 import {describe, it, before} from "mocha";
 import {expect} from 'chai';
 import {createFetcherStub} from "./util";
-import {PartnerApi} from "../src/PartnerApi";
-
+import {PartnerApi} from "../src";
 const ENDPOINT = 'ENDPOINT';
 const BR_AGENT_USER_ID = 'BR_AGENT_USER_ID';
 const BR_AGENT_ID = 'BR_AGENT_ID';

--- a/tests/util.js
+++ b/tests/util.js
@@ -6,7 +6,10 @@ export const createFetcherStub = () => {
     async fetch(url, params) {
       if (params.body instanceof FormData) {
         // Easier testing.
-        params.body = Object.fromEntries(params.body);
+        params.body = [...params.body].reduce((prevObject, [key, value]) => {
+          prevObject[key] = value;
+          return prevObject;
+        }, {});
       }
 
       this.result = {


### PR DESCRIPTION
См. https://github.com/rentsoft/rs/pull/3508

## Описание

По словам Данилы Трощинского, rescue использовать нельзя, потому что это небезопасно.
Поэтому мы убираем весь мёртвый код, связанный с rescue.

## План тестирования

- [x] Все тесты из `npm run test` должны проходить