### PR TITLE
[VEL-22497] Добавлен метод listServicesBySoftIdScopeObjId

### DIFF
--- a/src/BoApi.js
+++ b/src/BoApi.js
@@ -312,7 +312,7 @@ export class BoApi extends AbstractApi {
    * @param {string} scopeObjId
    * @returns {Promise<Response>}
    */
-  async listServicesBySoftIdScopeObjId(softId, scopeObjId) {
+  async listServicesBySoftIdDiscountScopeObjId(softId, scopeObjId) {
     return this.fetch(`api/service/list_by_soft_id_scope_obj_id/${softId}/${scopeObjId}`, {method: 'GET'});
   }
 

--- a/src/BoApi.js
+++ b/src/BoApi.js
@@ -308,6 +308,15 @@ export class BoApi extends AbstractApi {
   }
 
   /**
+   * @param {string} softId
+   * @param {string} scopeObjId
+   * @returns {Promise<Response>}
+   */
+  async listServicesBySoftIdScopeObjId(softId, scopeObjId) {
+    return this.fetch(`api/service/list_by_soft_id_scope_obj_id/${softId}/${scopeObjId}`, {method: 'GET'});
+  }
+
+  /**
    * @returns {Promise<Response>}
    */
   async listBrAgents() {

--- a/tests/bo-api-tests.js
+++ b/tests/bo-api-tests.js
@@ -283,8 +283,8 @@ describe('BoApi', function () {
         params: {method: 'GET'}
       }
     },
-    'listServicesBySoftIdScopeObjId': {
-      action: () => api.listServicesBySoftIdScopeObjId('200000000000000002', '200000000000000003'),
+    'listServicesBySoftDiscountScopeObjId': {
+      action: () => api.listServicesBySoftIdDiscountScopeObjId('200000000000000002', '200000000000000003'),
       expected: {
         url: 'ENDPOINT/api/service/list_by_soft_id_scope_obj_id/200000000000000002/200000000000000003?SESSID=SESSION',
         params: {method: 'GET'}

--- a/tests/bo-api-tests.js
+++ b/tests/bo-api-tests.js
@@ -283,6 +283,13 @@ describe('BoApi', function () {
         params: {method: 'GET'}
       }
     },
+    'listServicesBySoftIdScopeObjId': {
+      action: () => api.listServicesBySoftIdScopeObjId('200000000000000002', '200000000000000003'),
+      expected: {
+        url: 'ENDPOINT/api/service/list_by_soft_id_scope_obj_id/200000000000000002/200000000000000003?SESSID=SESSION',
+        params: {method: 'GET'}
+      }
+    },
     'listBrAgents': {
       action: () => api.listBrAgents(),
       expected: {


### PR DESCRIPTION
## Описание

Добавлен метод listServicesBySoftIdScopeObjId для поиска сервисов по продукту и scope_obj_id, чтобы реализовать функциональность, предложенную Ритой @kedaria: https://github.com/rentsoft/rs/pull/3894#issuecomment-809174071

v1.0.10